### PR TITLE
Turn off the dependabot for `npm` / `package.yaml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,13 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the action's `root` directory
-    directory: "/"
-    # Check the npm registry for updates every day (weekdays)
-    schedule:
-      interval: "monthly"
+  ## Andreas, 2023-09-10, turn off dependabot for npm since it does not keep the files in sync.
+  ## See https://github.com/haskell-actions/setup/issues/33
+  ##
+  # # Enable version updates for npm
+  # - package-ecosystem: "npm"
+  #   # Look for `package.json` and `lock` files in the action's `root` directory
+  #   directory: "/"
+  #   # Check the npm registry for updates every day (weekdays)
+  #   schedule:
+  #     interval: "monthly"


### PR DESCRIPTION
It does not properly regenerate the files, and breaks the sync between
`lib/` and `dist/`.
This breaks an invariant that is checked in our CI:
https://github.com/haskell-actions/setup/blob/e9c043c1211ab736db60bbab2b3f3c2771bb7722/.github/workflows/workflow.yml#L34-L35

Closes #33.
