### PR TITLE
Fix docs about cache in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,14 +159,14 @@ jobs:
 
       - name: Install dependencies
         # If we had an exact cache hit, the dependencies will be up to date.
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: cabal build all --only-dependencies
 
       # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
       - name: Save cached dependencies
         uses: actions/cache/save@v3
         # If we had an exact cache hit, trying to save the cache would error because of key clash.
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ steps.setup.outputs.cabal-store }}
           key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
Fantastic project - thank you 🙇 

I noticed small issue: [snippet with config for cache](https://github.com/haskell-actions/setup#model-cabal-workflow-with-caching) did not worked [for me](https://github.com/lemastero/agda2scheme/pull/3). This condition:
```
steps.cache.outputs.cache-hit != 'true'
```
was evaluated incorrectly and I had unexpected cache miss. Additionally cache with the same key was created multiple times.

Following change:
```
${{ steps.cache.outputs.cache-hit != 'true' }}
```
fixed this. This PR improve mentioned snippet, so it works out of the box.