### PR TITLE
Document how we obtain the name of the cabal config file.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14040,6 +14040,15 @@ async function cabalConfig() {
         silent: true,
         listeners: { stdout: append, stderr: append }
     });
+    // The last line of the cabal help text is printing the config file, e.g.:
+    //
+    // > You can edit the cabal configuration file to set defaults:
+    // >   <<HOME>>/.cabal/config
+    //
+    // So trimming the last line will give us the name of the config file.
+    //
+    // Needless to say this is very brittle, but we secure this by a test
+    // in Cabal's testsuite:  https://github.com/haskell/cabal/pull/9614
     return out.toString().trim().split('\n').slice(-1)[0].trim();
 }
 async function run(inputs) {

--- a/lib/setup-haskell.js
+++ b/lib/setup-haskell.js
@@ -42,6 +42,15 @@ async function cabalConfig() {
         silent: true,
         listeners: { stdout: append, stderr: append }
     });
+    // The last line of the cabal help text is printing the config file, e.g.:
+    //
+    // > You can edit the cabal configuration file to set defaults:
+    // >   <<HOME>>/.cabal/config
+    //
+    // So trimming the last line will give us the name of the config file.
+    //
+    // Needless to say this is very brittle, but we secure this by a test
+    // in Cabal's testsuite:  https://github.com/haskell/cabal/pull/9614
     return out.toString().trim().split('\n').slice(-1)[0].trim();
 }
 async function run(inputs) {

--- a/src/setup-haskell.ts
+++ b/src/setup-haskell.ts
@@ -16,6 +16,15 @@ async function cabalConfig(): Promise<string> {
     silent: true,
     listeners: {stdout: append, stderr: append}
   });
+  // The last line of the cabal help text is printing the config file, e.g.:
+  //
+  // > You can edit the cabal configuration file to set defaults:
+  // >   <<HOME>>/.cabal/config
+  //
+  // So trimming the last line will give us the name of the config file.
+  //
+  // Needless to say this is very brittle, but we secure this by a test
+  // in Cabal's testsuite:  https://github.com/haskell/cabal/pull/9614
   return out.toString().trim().split('\n').slice(-1)[0].trim();
 }
 


### PR DESCRIPTION
This adds a comment how we compute the name of the cabal configuration file from the output of `cabal --help`.

Inherently brittle, so we ensure its correctness upstream:
- https://github.com/haskell/cabal/pull/9614