### PR TITLE
Bump setup action to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,5 +60,5 @@ outputs:
   stack-root:
     description: 'The path to the stack root (equal to the STACK_ROOT environment variable if it is set; otherwise an OS-specific default)'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
@brandonchinn178 : Is the change (replacing `node16` by `node20`) sufficient to switch to node 20?  No change on the dependencies needed?

Along with this bump, I think we should bump the action to v3 and release the outstanding PRs:
- #6 
- #20 

What do you think?