### PR TITLE
Bump setup action to node20 (reprise)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
           cache: "npm"
           cache-dependency-path: package-lock.json
       - run: npm ci --prefer-offline --no-audit --progress=false

--- a/action.yml
+++ b/action.yml
@@ -60,5 +60,5 @@ outputs:
   stack-root:
     description: 'The path to the stack root (equal to the STACK_ROOT environment variable if it is set; otherwise an OS-specific default)'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Reapply "Bump setup action to node20".

We should also bump node in the workflow:
https://github.com/haskell-actions/setup/blob/802b61b9dcc72ea12635e9a082b4906326bbb3af/.github/workflows/workflow.yml#L26-L28
