### PR TITLE
Remove apt (ppa:hvr) fallback install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This action sets up a Haskell environment for use in actions by:
 The GitHub runners come with [pre-installed versions of GHC and Cabal](https://github.com/actions/runner-images).
 Those will be used whenever possible.
 For all other versions, this action utilizes
-[`ppa:hvr/ghc`](https://launchpad.net/~hvr/+archive/ubuntu/ghc),
 [`ghcup`](https://github.com/haskell/ghcup-hs), and
 [`chocolatey`](https://chocolatey.org/packages/ghc).
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -80,32 +80,24 @@ function warn(tool, version) {
         'If the list is outdated, please file an issue here: https://github.com/actions/runner-images/issues\n' +
         'by using the appropriate tool request template: https://github.com/actions/runner-images/issues/new/choose');
 }
-function aptVersion(tool, version) {
-    // For Cabal, extract the first two segments of the version number.
-    // This regex is intentionally liberal to accommodate unusual cases like "head".
-    return tool === 'cabal' ? /[^.]*\.?[^.]*/.exec(version)[0] : version;
-}
 async function isInstalled(tool, version, os, arch) {
     const toolPath = tc.find(tool, version);
     if (toolPath)
         return success(tool, version, toolPath, os);
     // Path where ghcup installs binaries
     const ghcupPath = os === 'win32' ? 'C:/ghcup/bin' : `${process_1.default.env.HOME}/.ghcup/bin`;
-    // Path where apt installs binaries of a tool
-    const v = aptVersion(tool, version);
-    const aptPath = `/opt/${tool}/${v}/bin`;
     // Path where choco installs binaries of a tool
     const chocoPath = await getChocoPath(tool, version, (0, opts_1.releaseRevision)(version, tool, os));
     const locations = {
         stack: [], // Always installed into the tool cache
         cabal: {
             win32: [chocoPath, ghcupPath],
-            linux: [aptPath, ghcupPath],
+            linux: [ghcupPath],
             darwin: [ghcupPath]
         }[os],
         ghc: {
             win32: [chocoPath, ghcupPath],
-            linux: [aptPath, ghcupPath],
+            linux: [ghcupPath],
             darwin: [ghcupPath]
         }[os]
     };
@@ -147,7 +139,7 @@ async function isInstalled(tool, version, os, arch) {
                 }
             }
             else {
-                // Install methods apt and choco have precise install paths,
+                // Install method choco has precise install paths,
                 // so if the install path is present, the tool should be present, too.
                 return success(tool, version, installedPath, os);
             }
@@ -186,9 +178,6 @@ async function installTool(tool, version, os, arch) {
                 await aptLibNCurses5();
             }
             await ghcup(tool, version, os, arch);
-            if (await isInstalled(tool, version, os, arch))
-                return;
-            await apt(tool, version);
             break;
         case 'win32':
             await choco(tool, version);
@@ -267,13 +256,6 @@ async function aptLibNCurses5() {
     await exec(`sudo -- sh -c "echo 'deb https://security.ubuntu.com/ubuntu focal-security main universe' > /etc/apt/sources.list.d/ubuntu-focal-sources.list"`);
     const returnCode = await exec(`sudo -- sh -c "apt-get update && apt-get -y install libncurses5 libtinfo5"`);
     return returnCode === 0;
-}
-async function apt(tool, version) {
-    const toolName = tool === 'ghc' ? 'ghc' : 'cabal-install';
-    const v = aptVersion(tool, version);
-    core.info(`Attempting to install ${toolName} ${v} using apt-get`);
-    // Ignore the return code so we can fall back to ghcup
-    await exec(`sudo -- sh -c "add-apt-repository -y ppa:hvr/ghc && apt-get update && apt-get -y install ${toolName}-${v}"`);
 }
 async function choco(tool, version) {
     core.info(`Attempting to install ${tool} ${version} using chocolatey`);


### PR DESCRIPTION
This PR replicates https://github.com/haskell/actions/pull/138 by Bodigrim.

For recent Ubuntu (> 20.04) the PPA hvr does not provide any GHC
releases, so this install method is now dead.
